### PR TITLE
fix: Updates OktaSdkBridge.swift build error

### DIFF
--- a/ios/OktaSdkBridge/OktaSdkBridge.swift
+++ b/ios/OktaSdkBridge/OktaSdkBridge.swift
@@ -561,8 +561,8 @@ class OktaSdkBridge: RCTEventEmitter {
 extension OktaSdkBridge: OktaNetworkRequestCustomizationDelegate {
     func customizableURLRequest(_ request: URLRequest?) -> URLRequest? {
         guard let timeout = requestTimeout,
-              let request = request,
-              let mutableRequestCopy = (request as NSURLRequest).mutableCopy() as? NSMutableURLRequest else
+              let auxRequest = request,
+              let mutableRequestCopy = (auxRequest as NSURLRequest).mutableCopy() as? NSMutableURLRequest else
         {
             return request
         }


### PR DESCRIPTION
Fixes a build bug on iOS due to error `variable declared in 'guard' condition is not usable in its body`
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our [guidelines](/okta/okta-react-native/blob/master/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [X] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
Getting an error trying to build the app in iOS: `variable declared in 'guard' condition is not usable in its body`.

Issue Number: N/A


## What is the new behavior?
the error is gone

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No